### PR TITLE
Adds events for other mods to integrate with

### DIFF
--- a/src/EldenParry.cpp
+++ b/src/EldenParry.cpp
@@ -128,6 +128,7 @@ bool EldenParry::processMeleeParry(RE::Actor* a_attacker, RE::Actor* a_parrier)
 		if (Settings::bSuccessfulParryNoCost) {
 			negateParryCost(a_parrier);
 		}
+		send_melee_parry_event(a_attacker);
 		return true;
 	}
 
@@ -166,6 +167,7 @@ bool EldenParry::processProjectileParry(RE::Actor* a_parrier, RE::Projectile* a_
 		if (Settings::bSuccessfulParryNoCost) {
 			negateParryCost(a_parrier);
 		}
+		send_ranged_parry_event();
 		return true;
 	}
 	return false;
@@ -251,6 +253,30 @@ void EldenParry::playGuardBashEffects(RE::Actor* a_actor) {
 			inlineUtils::shakeCamera(1.5, a_actor->GetPosition(), 0.4f);
 		}
 	}
+}
+
+void EldenParry::send_melee_parry_event(RE::Actor* a_attacker) {
+	SKSE::ModCallbackEvent modEvent{
+				RE::BSFixedString("EP_MeleeParryEvent"),
+				RE::BSFixedString(),
+				0.0f,
+				a_attacker
+	};
+
+	SKSE::GetModCallbackEventSource()->SendEvent(&modEvent);
+	logger::info("Sent melee parry event");
+}
+
+void EldenParry::send_ranged_parry_event() {
+	SKSE::ModCallbackEvent modEvent{
+				RE::BSFixedString("EP_RangedParryEvent"),
+				RE::BSFixedString(),
+				0.0f,
+				nullptr
+	};
+
+	SKSE::GetModCallbackEventSource()->SendEvent(&modEvent);
+	logger::info("Sent ranged parry event");
 }
 
 PRECISION_API::PreHitCallbackReturn EldenParry::precisionPrehitCallbackFunc(const PRECISION_API::PrecisionHitData& a_precisionHitData) {

--- a/src/EldenParry.h
+++ b/src/EldenParry.h
@@ -41,6 +41,9 @@ public:
 	void startTimingParry(RE::Actor* a_actor);
 	void finishTimingParry(RE::Actor* a_actor);
 
+	void send_melee_parry_event(RE::Actor* a_attacker);
+	void send_ranged_parry_event();
+
 	void update();
 
 private:


### PR DESCRIPTION
Hi! Big fan. Please accept this PR, which will allow other mods to integrate with Elden Parry. This will allow for things like 

Perk Overhaul integration 
Combat framework integrations
Other .dll plugin integrations 

This should have no negative consequences for current users. 

I have tested this while developing an mod integration between this and Ordinator, which I hope to publish soon. It would be great if you could accept this PR, build the changes, and update Elden Parry on Nexus to accommodate it. I think users would prefer that over having one .dll overwrite another. 

Thanks, and congrats on the Valhalla release! 
